### PR TITLE
decimal conversion bug fix

### DIFF
--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -608,6 +608,10 @@ contract Bridge is ReentrancyGuard {
             amount /= 10**(decimals - 8);
         }
 
+        if ( decimals < 8 ) {
+            amount *= 10**(8 - decimals);
+        }
+
         return amount;
     }
 
@@ -623,6 +627,10 @@ contract Bridge is ReentrancyGuard {
     {
         if (decimals > 8) {
             amount *= 10**(decimals - 8);
+        }
+
+        if (decimals < 8) {
+            amount /= 10**(8 - decimals);
         }
 
         return amount;


### PR DESCRIPTION
Correction was added to the decimal conversion for when the decimals are less than 8, such as USDT in the Ethereum network, The USDT token currently on the eth network has a total of 6 decimal places, very different from the USDT token on the BSC network which has a total of 18 decimal places, the decimals of both tokens can be verified in the following links:

https://etherscan.io/token/0xdac17f958d2ee523a2206206994597c13d831ec7#readContract
https://www.bscscan.com/address/0x55d398326f99059ff775485246999027b3197955#readContract

Solution:

The solution to this problem is to add or remove decimals to reach a limit of 8 decimals per token. For this, the following formulas are used.

**Add decimals:** amount *= 10**(8 - decimals);
**Remove decimals:**  amount /= 10**(decimals - 8);


